### PR TITLE
Update Travis CI notification settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: java
+notifications:
+  email:
+    on_failure: change
+    on_success: never


### PR DESCRIPTION
- 1 email when tests start failing
- no emails when tests are passing