### PR TITLE
RPC client refactoring to divide responsibilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,30 +11,30 @@
     <url>https://github.com/kiwitcms/junit-plugin</url>
 
     <scm>
-      <connection>scm:git:git://github.com/kiwitcms/junit-plugin.git</connection>
-      <developerConnection>scm:git:ssh://github.com:kiwitcms/junit-plugin.git</developerConnection>
-      <url>https://github.com/kiwitcms/junit-plugin</url>
+        <connection>scm:git:git://github.com/kiwitcms/junit-plugin.git</connection>
+        <developerConnection>scm:git:ssh://github.com:kiwitcms/junit-plugin.git</developerConnection>
+        <url>https://github.com/kiwitcms/junit-plugin</url>
     </scm>
 
     <licenses>
-      <license>
-        <name>GNU General Public License, Version 3.0</name>
-        <url>https://opensource.org/licenses/GPL-3.0</url>
-      </license>
+        <license>
+            <name>GNU General Public License, Version 3.0</name>
+            <url>https://opensource.org/licenses/GPL-3.0</url>
+        </license>
     </licenses>
 
     <developers>
         <developer>
-          <name>Aneta Petkova</name>
-          <email>aneta.v.petkova@gmail.com</email>
-          <organization>Independent contributor</organization>
-          <organizationUrl>https://github.com/apetkova</organizationUrl>
+            <name>Aneta Petkova</name>
+            <email>aneta.v.petkova@gmail.com</email>
+            <organization>Independent contributor</organization>
+            <organizationUrl>https://github.com/apetkova</organizationUrl>
         </developer>
         <developer>
-          <name>Alexander Todorov</name>
-          <email>atodorov@otb.bg</email>
-          <organization>Kiwi TCMS</organization>
-          <organizationUrl>http://kiwitcms.org</organizationUrl>
+            <name>Alexander Todorov</name>
+            <email>atodorov@otb.bg</email>
+            <organization>Kiwi TCMS</organization>
+            <organizationUrl>http://kiwitcms.org</organizationUrl>
         </developer>
     </developers>
 
@@ -53,7 +53,7 @@
     <!-- Maven Central release profile -->
     <profiles>
         <profile>
-        <id>release</id>
+            <id>release</id>
             <build>
                 <plugins>
                     <plugin>
@@ -121,8 +121,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>3.0.0-M3</version>
+                <configuration>
+                    <properties>
+                        <configurationParameters>
+                            junit.jupiter.extensions.autodetection.enabled=true
+                        </configurationParameters>
+                    </properties>
+                </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -175,7 +183,7 @@
                 </executions>
                 <configuration>
                     <!--<systemPropertyVariables>-->
-                        <!--<jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>-->
+                    <!--<jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>-->
                     <!--</systemPropertyVariables>-->
                 </configuration>
             </plugin>
@@ -187,7 +195,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.4.1</version>
+            <version>5.5.0-M1</version>
             <scope>compile</scope>
         </dependency>
 
@@ -195,7 +203,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.1</version>
+            <version>5.5.0-M1</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/org/kiwitcms/java/api/BaseRpcClient.java
+++ b/src/main/java/org/kiwitcms/java/api/BaseRpcClient.java
@@ -19,7 +19,7 @@ public class BaseRpcClient {
 
     public static final String BASE_URL = Config.getInstance().getKiwiUrl();
 
-    protected String sessionId;
+    protected static String sessionId;
 
     protected JSONRPC2Session prepareSession(){
         URL serverURL = null;

--- a/src/main/java/org/kiwitcms/java/api/KiwiJsonRpcClient.java
+++ b/src/main/java/org/kiwitcms/java/api/KiwiJsonRpcClient.java
@@ -51,13 +51,13 @@ public class KiwiJsonRpcClient extends BaseRpcClient {
         }
     }
 
-    public TestCase createNewTC(int categoryId, int priorityId, int caseStatusId, String summary) {
-        return testingClient.createNewTC(categoryId, priorityId, caseStatusId, summary);
+    public TestCase createNewTC(int productId, int categoryId, int priorityId, int caseStatusId, String summary) {
+        return testingClient.createNewTC(productId, categoryId, priorityId, caseStatusId, summary);
     }
 
-    public TestCase createNewConfirmedTC(int categoryId, int priorityId, String summary) {
+    public TestCase createNewConfirmedTC(int productId, int categoryId, int priorityId, String summary) {
         int caseStatusId = testingClient.getConfirmedTCStatusId();
-        return testingClient.createNewTC(categoryId, priorityId, caseStatusId, summary);
+        return testingClient.createNewTC(productId, categoryId, priorityId, caseStatusId, summary);
     }
 
     public TestRun createNewRun(int build, String manager, int plan, String summary) {
@@ -66,6 +66,10 @@ public class KiwiJsonRpcClient extends BaseRpcClient {
 
     public TestCase[] getRunIdTestCases(int runId) {
         return testingClient.getRunIdTestCases(runId);
+    }
+
+    public TestCase[] getPlanIdTestCases(int planId) {
+        return testingClient.getPlanIdTestCases(planId);
     }
 
     public TestCaseRun addTestCaseToRunId(int runId, int caseId) {
@@ -78,6 +82,10 @@ public class KiwiJsonRpcClient extends BaseRpcClient {
 
     public TestPlan createNewTP(int productId, String name, int versionId) {
         return testingClient.createNewTP(productId, name, versionId);
+    }
+
+    public int getTestPlanId(String name, int productId){
+        return testingClient.getTestPlanId(name, productId);
     }
 
     public void addTestCaseToPlan(int planId, int caseId) {

--- a/src/main/java/org/kiwitcms/java/api/KiwiJsonRpcClient.java
+++ b/src/main/java/org/kiwitcms/java/api/KiwiJsonRpcClient.java
@@ -4,18 +4,14 @@
 
 package org.kiwitcms.java.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.kiwitcms.java.config.Config;
 import org.kiwitcms.java.model.*;
 import com.thetransactioncompany.jsonrpc2.JSONRPC2Request;
 import com.thetransactioncompany.jsonrpc2.client.JSONRPC2Session;
 import com.thetransactioncompany.jsonrpc2.client.JSONRPC2SessionException;
 import net.minidev.json.JSONArray;
-import net.minidev.json.JSONObject;
 
-import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 
 
@@ -23,316 +19,15 @@ public class KiwiJsonRpcClient extends BaseRpcClient {
 
     public static final String LOGIN_METHOD = "Auth.login";
     public static final String LOGOUT_METHOD = "Auth.logout";
-    public static final String GET_RUN_TCS_METHOD = "TestRun.get_cases";
-    public static final String CREATE_RUN_METHOD = "TestRun.create";
-    public static final String CREATE_TC_METHOD = "TestCase.create";
-    public static final String ADD_TC_TO_RUN_METHOD = "TestRun.add_case";
-    public static final String RUN_FILTER = "TestRun.filter";
-    public static final String PRODUCT_FILTER = "Product.filter";
-    public static final String CREATE_PRODUCT_METHOD = "Product.create";
-    public static final String BUILD_FILTER = "Build.filter";
-    public static final String CREATE_BUILD_METHOD = "Build.create";
-    public static final String ADD_TC_TO_PLAN_METHOD = "TestPlan.add_case";
-    public static final String CREATE_PLAN_METHOD = "TestPlan.create";
-    public static final String TEST_PLAN_FILTER = "TestPlan.filter";
-    public static final String TEST_CASE_RUN_FILTER = "TestCaseRun.filter";
-    public static final String CREATE_TC_RUN_METHOD = "TestCaseRun.create";
-    public static final String UPDATE_TC_RUN_METHOD = "TestCaseRun.update";
-    public static final String CREATE_VERSION_METHOD = "Version.create";
-    public static final String VERSION_FILTER = "Version.filter";
-    public static final String PRIORITY_FILTER = "Priority.filter";
 
-    public TestCase createNewTC(int product, String summary) {
-        Map<String, Object> params = new HashMap<>();
 
-        // TODO: these should be moved in the constructor
-        // get the first possible priority
-        JSONArray jsonArray = (JSONArray) callPosParamService(PRIORITY_FILTER, Arrays.asList((Object) params));
-        Object priority = ((JSONObject)jsonArray.get(0)).get("id");
+    private KiwiProductJsonRpcClient productClient;
+    private KiwiTestingJsonRpcClient testingClient;
 
-        // get the first possible category
-        params.put("product", product);
-        jsonArray = (JSONArray) callPosParamService("Category.filter", Arrays.asList((Object) params));
-        Object category = ((JSONObject)jsonArray.get(0)).get("id");
-
-        params.put("category", category);
-        params.put("summary", summary);
-        params.put("is_automated", "true");
-        params.put("priority", priority);
-
-        // get confirmed status
-        Map<String, Object> confirmed_params = new HashMap<>();
-        confirmed_params.put("name", "CONFIRMED");
-        jsonArray = (JSONArray) callPosParamService("TestCaseStatus.filter", Arrays.asList((Object) confirmed_params));
-        Object confirmed = ((JSONObject)jsonArray.get(0)).get("id");
-        params.put("case_status", confirmed);
-
-        JSONObject json = (JSONObject) callPosParamService(CREATE_TC_METHOD, Arrays.asList((Object) params));
-        try {
-            return new ObjectMapper().readValue(json.toJSONString(), TestCase.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    public TestRun createNewRun(int build, String manager, int plan, String summary) {
-        Map<String, Object> params = new HashMap<>();
-        params.put("build", build);
-        params.put("manager", manager);
-        params.put("plan", plan);
-        params.put("summary", summary);
-        JSONObject json = (JSONObject) callPosParamService(CREATE_RUN_METHOD, Arrays.asList((Object) params));
-        try {
-            return new ObjectMapper().readValue(json.toJSONString(), TestRun.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    public TestCase[] getRunIdTestCases(int runId) {
-        JSONArray jsonArray = (JSONArray) callPosParamService(GET_RUN_TCS_METHOD, Arrays.asList((Object) runId));
-        try {
-            return new ObjectMapper().readValue(jsonArray.toJSONString(), TestCase[].class);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return new TestCase[0];
-        }
-    }
-
-    public TestCaseRun addTestCaseToRunId(int runId, int caseId) {
-        Map<String, Object> params = new HashMap<>();
-        params.put("run_id", runId);
-        params.put("case_id", caseId);
-
-        JSONObject json = (JSONObject) callNameParamService(ADD_TC_TO_RUN_METHOD, params);
-        try {
-            return new ObjectMapper().readValue(json.toJSONString(), TestCaseRun.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    public boolean planExists(int planId) {
-        Map<String, Object> filter = new HashMap<>();
-        filter.put("pk", planId);
-        JSONArray jsonArray = (JSONArray) callPosParamService(TEST_PLAN_FILTER, Arrays.asList((Object) filter));
-        return !jsonArray.isEmpty();
-    }
-
-    public Integer getProductId(String name) {
-        Map<String, Object> filter = new HashMap<>();
-        filter.put("name", name);
-        JSONArray jsonArray = (JSONArray) callPosParamService(PRODUCT_FILTER, Arrays.asList((Object) filter));
-        if (jsonArray.isEmpty()) {
-            return null;
-        } else {
-            try {
-                Product[] product = new ObjectMapper().readValue(jsonArray.toJSONString(), Product[].class);
-                return product[0].getId();
-            } catch (IOException e) {
-                e.printStackTrace();
-                return null;
-            }
-        }
-    }
-
-    public Product createNewProduct(String name) {
-        Map<String, Object> params = new HashMap<>();
-
-        // TODO: move classification filtering in constructor
-        // get the first possible classification
-        JSONArray jsonArray = (JSONArray) callPosParamService("Classification.filter", Arrays.asList((Object) params));
-        Object classification_id = ((JSONObject)jsonArray.get(0)).get("id");
-
-        params.put("name", name);
-        params.put("classification_id", classification_id);
-
-        JSONObject json = (JSONObject) callPosParamService(CREATE_PRODUCT_METHOD, Arrays.asList((Object) params));
-        try {
-            return new ObjectMapper().readValue(json.toJSONString(), Product.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    public TestRun getRun(int runId) {
-        Map<String, Object> filter = new HashMap<>();
-        filter.put("run_id", runId);
-
-        JSONArray jsonArray = (JSONArray) callPosParamService(RUN_FILTER, Arrays.asList((Object) filter));
-        if (jsonArray == null || jsonArray.isEmpty()) {
-            return null;
-        } else {
-            try {
-                TestRun[] run = new ObjectMapper().readValue(jsonArray.toJSONString(), TestRun[].class);
-                return run[0];
-            } catch (IOException e) {
-                e.printStackTrace();
-                return null;
-            }
-        }
-    }
-
-    public TestPlan createNewTP(int productId, String name, int versionId) {
-        // TODO: move this in the constructor
-        Map<String, Object> params = new HashMap<>();
-        params.put("name", "Unit");  // todo: this will need to change for TestNG
-        JSONArray jsonArray = (JSONArray) callPosParamService("PlanType.filter", Arrays.asList((Object) params));
-        Object type = ((JSONObject)jsonArray.get(0)).get("id");
-
-        params = new HashMap<>();
-        params.put("product", productId);
-        params.put("type", type);
-        params.put("default_product_version", 0);
-        params.put("product_version", versionId);
-        params.put("text", "WIP");
-        params.put("is_active", true);
-        params.put("name", name);
-        JSONObject json = (JSONObject) callPosParamService(CREATE_PLAN_METHOD, Arrays.asList((Object) params));
-        try {
-            return new ObjectMapper().readValue(json.toJSONString(), TestPlan.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    public void addTestCaseToPlan(int planId, int caseId) {
-        Map<String, Object> params = new HashMap<>();
-        params.put("plan_id", planId);
-        params.put("case_id", caseId);
-
-        callNameParamService(ADD_TC_TO_PLAN_METHOD, params);
-    }
-
-    public Build[] getBuilds(Map<String, Object> filter) {
-        JSONArray jsonArray = (JSONArray) callPosParamService(BUILD_FILTER, Arrays.asList((Object) filter));
-        if (jsonArray.isEmpty()) {
-            return new Build[0];
-        } else {
-            try {
-                Build[] builds = new ObjectMapper().readValue(jsonArray.toJSONString(), Build[].class);
-                return builds;
-            } catch (IOException e) {
-                e.printStackTrace();
-                return new Build[0];
-            }
-        }
-    }
-
-    public Build createBuild(String name, int productId) {
-        Map<String, Object> params = new HashMap<>();
-        params.put("name", name);
-        params.put("product", productId);
-        JSONObject json = (JSONObject) callPosParamService(CREATE_BUILD_METHOD, Arrays.asList((Object) params));
-        try {
-            return new ObjectMapper().readValue(json.toJSONString(), Build.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    public TestCaseRun getTestCaseRun(Map<String, Object> filter) {
-        JSONArray jsonArray = (JSONArray) callPosParamService(TEST_CASE_RUN_FILTER, Arrays.asList((Object) filter));
-        if (jsonArray.isEmpty()) {
-            return null;
-        } else {
-            System.out.println(jsonArray.toJSONString());
-            try {
-                TestCaseRun[] tcRun = new ObjectMapper().readValue(jsonArray.toJSONString(), TestCaseRun[].class);
-                return tcRun[0];
-            } catch (IOException e) {
-                e.printStackTrace();
-                return null;
-            }
-        }
-    }
-
-    public TestCaseRun createTestCaseRun(int runId, int caseId, int build, int status) {
-        Map<String, Object> params = new HashMap<>();
-        params.put("run", runId);
-        params.put("case", caseId);
-        params.put("build", build);
-        params.put("status", status);
-
-        JSONObject json = (JSONObject) callPosParamService(CREATE_TC_RUN_METHOD, Arrays.asList((Object) params));
-        try {
-            System.out.println(json.toJSONString());
-            return new ObjectMapper().readValue(json.toJSONString(), TestCaseRun.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    public TestCaseRun updateTestCaseRun(int tcRunId, int status) {
-        Map<String, Object> values = new HashMap<>();
-        values.put("status", status);
-
-        Map<String, Object> params = new HashMap<>();
-        params.put("case_run_id", tcRunId);
-        params.put("values", values);
-        JSONObject json = (JSONObject) callNameParamService(UPDATE_TC_RUN_METHOD, params);
-        try {
-            return new ObjectMapper().readValue(json.toJSONString(), TestCaseRun.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    public Version[] getVersions(Map<String, Object> filter) {
-        JSONArray jsonArray = (JSONArray) callPosParamService(VERSION_FILTER, Arrays.asList((Object) filter));
-        if (jsonArray.isEmpty()) {
-            return new Version[0];
-        } else {
-            try {
-                Version[] versions = new ObjectMapper().readValue(jsonArray.toJSONString(), Version[].class);
-                return versions;
-            } catch (IOException e) {
-                e.printStackTrace();
-                return new Version[0];
-            }
-        }
-    }
-
-    public Version createProductVersion(String version, int productId) {
-        Map<String, Object> params = new HashMap<>();
-        params.put("value", version);
-        params.put("product", productId);
-
-        JSONObject json = (JSONObject) callPosParamService(CREATE_VERSION_METHOD, Arrays.asList((Object) params));
-        try {
-            return new ObjectMapper().readValue(json.toJSONString(), Version.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    public Priority[] getPriority(Map<String, Object> filter) {
-        JSONArray jsonArray = (JSONArray) callPosParamService(PRIORITY_FILTER, Arrays.asList((Object) filter));
-        if (jsonArray.isEmpty()) {
-            return new Priority[0];
-        } else {
-            try {
-                Priority[] priorities = new ObjectMapper().readValue(jsonArray.toJSONString(), Priority[].class);
-                return priorities;
-            } catch (IOException e) {
-                e.printStackTrace();
-                return new Priority[0];
-            }
-        }
-    }
-
-    public String login(String username, String password) {
-        sessionId = (String) callPosParamService(LOGIN_METHOD, Arrays.asList(username, password));
-        return sessionId;
+    public KiwiJsonRpcClient(){
+        super();
+        productClient = new KiwiProductJsonRpcClient();
+        testingClient = new KiwiTestingJsonRpcClient();
     }
 
     //TODO: Seems a bad practice, remove/replace
@@ -355,5 +50,87 @@ public class KiwiJsonRpcClient extends BaseRpcClient {
             System.err.println(e.getMessage());
         }
     }
-//    com.thetransactioncompany.jsonrpc2.JSONRPC2Error
+
+    public TestCase createNewTC(int categoryId, int priorityId, int caseStatusId, String summary) {
+        return testingClient.createNewTC(categoryId, priorityId, caseStatusId, summary);
+    }
+
+    public TestCase createNewConfirmedTC(int categoryId, int priorityId, String summary) {
+        int caseStatusId = testingClient.getConfirmedTCStatusId();
+        return testingClient.createNewTC(categoryId, priorityId, caseStatusId, summary);
+    }
+
+    public TestRun createNewRun(int build, String manager, int plan, String summary) {
+       return testingClient.createNewRun(build, manager, plan, summary);
+    }
+
+    public TestCase[] getRunIdTestCases(int runId) {
+        return testingClient.getRunIdTestCases(runId);
+    }
+
+    public TestCaseRun addTestCaseToRunId(int runId, int caseId) {
+        return testingClient.addTestCaseToRunId(runId, caseId);
+    }
+
+    public TestRun getRun(int runId) {
+        return testingClient.getRun(runId);
+    }
+
+    public TestPlan createNewTP(int productId, String name, int versionId) {
+        return testingClient.createNewTP(productId, name, versionId);
+    }
+
+    public void addTestCaseToPlan(int planId, int caseId) {
+        testingClient.addTestCaseToPlan(planId, caseId);
+    }
+
+    public TestCaseRun getTestCaseRun(Map<String, Object> filter) {
+       return testingClient.getTestCaseRun(filter);
+    }
+
+    public TestCaseRun createTestCaseRun(int runId, int caseId, int build, int status) {
+       return testingClient.createTestCaseRun(runId, caseId, build, status);
+    }
+
+    public TestCaseRun updateTestCaseRun(int tcRunId, int status) {
+       return testingClient.updateTestCaseRun(tcRunId, status);
+    }
+
+    public String login(String username, String password) {
+        sessionId = (String) callPosParamService(LOGIN_METHOD, Arrays.asList(username, password));
+        return sessionId;
+    }
+
+    public Integer getProductId(String name) {
+        return productClient.getProductId(name);
+    }
+
+    public Product createNewProduct(String name) {
+        return productClient.createNewProduct(name);
+    }
+
+    public Build[] getBuilds(Map<String, Object> filter) {
+        return productClient.getBuilds(filter);
+    }
+
+    public Build createBuild(String name, int productId) {
+        return productClient.createBuild(name, productId);
+    }
+
+    public Version[] getVersions(Map<String, Object> filter) {
+       return productClient.getVersions(filter);
+    }
+
+    public Version createProductVersion(String version, int productId) {
+       return productClient.createProductVersion(version, productId);
+    }
+
+    public Priority[] getPriority(Map<String, Object> filter) {
+        return productClient.getPriority(filter);
+    }
+
+    // TODO: Create Category class
+    public JSONArray getCategory(Map<String, Object> filter) {
+        return productClient.getCategory(filter);
+    }
 }

--- a/src/main/java/org/kiwitcms/java/api/KiwiProductJsonRpcClient.java
+++ b/src/main/java/org/kiwitcms/java/api/KiwiProductJsonRpcClient.java
@@ -1,0 +1,139 @@
+package org.kiwitcms.java.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import org.kiwitcms.java.model.Build;
+import org.kiwitcms.java.model.Priority;
+import org.kiwitcms.java.model.Product;
+import org.kiwitcms.java.model.Version;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class KiwiProductJsonRpcClient extends BaseRpcClient {
+
+    private static final String PRODUCT_FILTER = "Product.filter";
+    private static final String CREATE_PRODUCT_METHOD = "Product.create";
+    private static final String BUILD_FILTER = "Build.filter";
+    private static final String CREATE_BUILD_METHOD = "Build.create";
+    private static final String CREATE_VERSION_METHOD = "Version.create";
+    private static final String VERSION_FILTER = "Version.filter";
+    private static final String PRIORITY_FILTER = "Priority.filter";
+    private static final String CATEGORY_FILTER = "Category.filter";
+
+    Integer getProductId(String name) {
+        Map<String, Object> filter = new HashMap<>();
+        filter.put("name", name);
+        JSONArray jsonArray = (JSONArray) callPosParamService(PRODUCT_FILTER, Arrays.asList((Object) filter));
+        if (jsonArray.isEmpty()) {
+            return null;
+        } else {
+            try {
+                Product[] product = new ObjectMapper().readValue(jsonArray.toJSONString(), Product[].class);
+                return product[0].getId();
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }
+    }
+
+    Product createNewProduct(String name) {
+        Map<String, Object> params = new HashMap<>();
+
+        // TODO: move classification filtering in emitter
+        // get the first possible classification
+        JSONArray jsonArray = (JSONArray) callPosParamService("Classification.filter", Arrays.asList((Object) params));
+        Object classificationId = ((JSONObject) jsonArray.get(0)).get("id");
+
+        params.put("name", name);
+        params.put("classification_id", classificationId);
+
+        JSONObject json = (JSONObject) callPosParamService(CREATE_PRODUCT_METHOD, Arrays.asList((Object) params));
+        try {
+            return new ObjectMapper().readValue(json.toJSONString(), Product.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    Build[] getBuilds(Map<String, Object> filter) {
+        JSONArray jsonArray = (JSONArray) callPosParamService(BUILD_FILTER, Arrays.asList((Object) filter));
+        if (jsonArray.isEmpty()) {
+            return new Build[0];
+        } else {
+            try {
+                Build[] builds = new ObjectMapper().readValue(jsonArray.toJSONString(), Build[].class);
+                return builds;
+            } catch (IOException e) {
+                e.printStackTrace();
+                return new Build[0];
+            }
+        }
+    }
+
+    Build createBuild(String name, int productId) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("name", name);
+        params.put("product", productId);
+        JSONObject json = (JSONObject) callPosParamService(CREATE_BUILD_METHOD, Arrays.asList((Object) params));
+        try {
+            return new ObjectMapper().readValue(json.toJSONString(), Build.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    Version[] getVersions(Map<String, Object> filter) {
+        JSONArray jsonArray = (JSONArray) callPosParamService(VERSION_FILTER, Arrays.asList((Object) filter));
+        if (jsonArray.isEmpty()) {
+            return new Version[0];
+        } else {
+            try {
+                Version[] versions = new ObjectMapper().readValue(jsonArray.toJSONString(), Version[].class);
+                return versions;
+            } catch (IOException e) {
+                e.printStackTrace();
+                return new Version[0];
+            }
+        }
+    }
+
+    Version createProductVersion(String version, int productId) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("value", version);
+        params.put("product", productId);
+
+        JSONObject json = (JSONObject) callPosParamService(CREATE_VERSION_METHOD, Arrays.asList((Object) params));
+        try {
+            return new ObjectMapper().readValue(json.toJSONString(), Version.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    Priority[] getPriority(Map<String, Object> filter) {
+        JSONArray jsonArray = (JSONArray) callPosParamService(PRIORITY_FILTER, Arrays.asList((Object) filter));
+        if (jsonArray.isEmpty()) {
+            return new Priority[0];
+        } else {
+            try {
+                return new ObjectMapper().readValue(jsonArray.toJSONString(), Priority[].class);
+            } catch (IOException e) {
+                e.printStackTrace();
+                return new Priority[0];
+            }
+        }
+    }
+
+    // TODO: Create Category class
+    JSONArray getCategory(Map<String, Object> filter) {
+        return (JSONArray) callPosParamService(CATEGORY_FILTER, Arrays.asList((Object) filter));
+    }
+}

--- a/src/main/java/org/kiwitcms/java/api/KiwiTestingJsonRpcClient.java
+++ b/src/main/java/org/kiwitcms/java/api/KiwiTestingJsonRpcClient.java
@@ -1,0 +1,206 @@
+package org.kiwitcms.java.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import org.kiwitcms.java.model.TestCase;
+import org.kiwitcms.java.model.TestCaseRun;
+import org.kiwitcms.java.model.TestPlan;
+import org.kiwitcms.java.model.TestRun;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class KiwiTestingJsonRpcClient extends BaseRpcClient {
+    public static final String GET_RUN_TCS_METHOD = "TestRun.get_cases";
+    public static final String CREATE_RUN_METHOD = "TestRun.create";
+    public static final String CREATE_TC_METHOD = "TestCase.create";
+    public static final String ADD_TC_TO_RUN_METHOD = "TestRun.add_case";
+    public static final String RUN_FILTER = "TestRun.filter";
+    public static final String ADD_TC_TO_PLAN_METHOD = "TestPlan.add_case";
+    public static final String CREATE_PLAN_METHOD = "TestPlan.create";
+    public static final String TEST_PLAN_FILTER = "TestPlan.filter";
+    public static final String TEST_CASE_RUN_FILTER = "TestCaseRun.filter";
+    public static final String CREATE_TC_RUN_METHOD = "TestCaseRun.create";
+    public static final String UPDATE_TC_RUN_METHOD = "TestCaseRun.update";
+    public static final String TEST_CASE_STATUS_FILTER = "TestCaseStatus.filter";
+
+    TestCase createNewTC(int categoryId, int priorityId, int caseStatusId, String summary) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("category", categoryId);
+        params.put("summary", summary);
+        params.put("is_automated", "true");
+        params.put("priority", priorityId);
+        params.put("case_status", caseStatusId);
+
+        JSONObject json = (JSONObject) callPosParamService(CREATE_TC_METHOD, Arrays.asList((Object) params));
+        try {
+            return new ObjectMapper().readValue(json.toJSONString(), TestCase.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    TestRun createNewRun(int build, String manager, int plan, String summary) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("build", build);
+        params.put("manager", manager);
+        params.put("plan", plan);
+        params.put("summary", summary);
+        JSONObject json = (JSONObject) callPosParamService(CREATE_RUN_METHOD, Arrays.asList((Object) params));
+        try {
+            return new ObjectMapper().readValue(json.toJSONString(), TestRun.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    TestCase[] getRunIdTestCases(int runId) {
+        JSONArray jsonArray = (JSONArray) callPosParamService(GET_RUN_TCS_METHOD, Arrays.asList((Object) runId));
+        try {
+            return new ObjectMapper().readValue(jsonArray.toJSONString(), TestCase[].class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return new TestCase[0];
+        }
+    }
+
+    TestCaseRun addTestCaseToRunId(int runId, int caseId) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("run_id", runId);
+        params.put("case_id", caseId);
+
+        JSONObject json = (JSONObject) callNameParamService(ADD_TC_TO_RUN_METHOD, params);
+        try {
+            return new ObjectMapper().readValue(json.toJSONString(), TestCaseRun.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    boolean planExists(int planId) {
+        Map<String, Object> filter = new HashMap<>();
+        filter.put("pk", planId);
+        JSONArray jsonArray = (JSONArray) callPosParamService(TEST_PLAN_FILTER, Arrays.asList((Object) filter));
+        return !jsonArray.isEmpty();
+    }
+
+
+    TestRun getRun(int runId) {
+        Map<String, Object> filter = new HashMap<>();
+        filter.put("run_id", runId);
+
+        JSONArray jsonArray = (JSONArray) callPosParamService(RUN_FILTER, Arrays.asList((Object) filter));
+        if (jsonArray == null || jsonArray.isEmpty()) {
+            return null;
+        } else {
+            try {
+                TestRun[] run = new ObjectMapper().readValue(jsonArray.toJSONString(), TestRun[].class);
+                return run[0];
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }
+    }
+
+    TestPlan createNewTP(int productId, String name, int versionId) {
+        // TODO: move this in the constructor
+        Map<String, Object> params = new HashMap<>();
+        params.put("name", "Unit");  // todo: this will need to change for TestNG
+        JSONArray jsonArray = (JSONArray) callPosParamService("PlanType.filter", Arrays.asList((Object) params));
+        Object type = ((JSONObject) jsonArray.get(0)).get("id");
+
+        params = new HashMap<>();
+        params.put("product", productId);
+        params.put("type", type);
+        params.put("default_product_version", 0);
+        params.put("product_version", versionId);
+        params.put("text", "WIP");
+        params.put("is_active", true);
+        params.put("name", name);
+        JSONObject json = (JSONObject) callPosParamService(CREATE_PLAN_METHOD, Arrays.asList((Object) params));
+        try {
+            return new ObjectMapper().readValue(json.toJSONString(), TestPlan.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    void addTestCaseToPlan(int planId, int caseId) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("plan_id", planId);
+        params.put("case_id", caseId);
+
+        callNameParamService(ADD_TC_TO_PLAN_METHOD, params);
+    }
+
+    TestCaseRun getTestCaseRun(Map<String, Object> filter) {
+        JSONArray jsonArray = (JSONArray) callPosParamService(TEST_CASE_RUN_FILTER, Arrays.asList((Object) filter));
+        if (jsonArray.isEmpty()) {
+            return null;
+        } else {
+            System.out.println(jsonArray.toJSONString());
+            try {
+                TestCaseRun[] tcRun = new ObjectMapper().readValue(jsonArray.toJSONString(), TestCaseRun[].class);
+                return tcRun[0];
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }
+    }
+
+    TestCaseRun createTestCaseRun(int runId, int caseId, int build, int status) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("run", runId);
+        params.put("case", caseId);
+        params.put("build", build);
+        params.put("status", status);
+
+        JSONObject json = (JSONObject) callPosParamService(CREATE_TC_RUN_METHOD, Arrays.asList((Object) params));
+        try {
+            System.out.println(json.toJSONString());
+            return new ObjectMapper().readValue(json.toJSONString(), TestCaseRun.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    TestCaseRun updateTestCaseRun(int tcRunId, int status) {
+        Map<String, Object> values = new HashMap<>();
+        values.put("status", status);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("case_run_id", tcRunId);
+        params.put("values", values);
+        JSONObject json = (JSONObject) callNameParamService(UPDATE_TC_RUN_METHOD, params);
+        try {
+            return new ObjectMapper().readValue(json.toJSONString(), TestCaseRun.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    // TODO: Create TestCaseStatus class
+    JSONArray getTestCaseStatus(Map<String, Object> filter) {
+        JSONArray jsonArray = (JSONArray) callPosParamService(TEST_CASE_STATUS_FILTER, Arrays.asList((Object) filter));
+        return jsonArray;
+    }
+
+    //Get first available
+    int getConfirmedTCStatusId() {
+        Map<String, Object> confirmed_params = new HashMap<>();
+        confirmed_params.put("name", "CONFIRMED");
+        Object id = ((JSONObject) getTestCaseStatus(confirmed_params).get(0)).get("id");
+        return Integer.parseInt(String.valueOf(id));
+    }
+}

--- a/src/main/java/org/kiwitcms/java/model/Priority.java
+++ b/src/main/java/org/kiwitcms/java/model/Priority.java
@@ -7,14 +7,14 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 public class Priority {
     private String name;
     private int id;
-    private int productId;
+    private boolean isActive;
 
 
     public String getName() {
         return name;
     }
 
-    @JsonSetter("name")
+    @JsonSetter("value")
     public void setName(String name) {
         this.name = name;
     }
@@ -23,17 +23,17 @@ public class Priority {
         return id;
     }
 
-    @JsonSetter("priority_id")
+    @JsonSetter("id")
     public void setId(int id) {
         this.id = id;
     }
 
-    public int getProductId() {
-        return productId;
+    public boolean isActive() {
+        return isActive;
     }
 
-    @JsonSetter("product_id")
-    public void setProductId(int productId) {
-        this.productId = productId;
+    @JsonSetter("is_active")
+    public void setActive(boolean isActive) {
+        this.isActive = isActive;
     }
 }

--- a/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.kiwitcms.java.junit.KiwiTcmsExtension

--- a/src/test/java/org/kiwitcms/java/api/KiwiJsonRpcClientTest.java
+++ b/src/test/java/org/kiwitcms/java/api/KiwiJsonRpcClientTest.java
@@ -4,11 +4,7 @@
 
 package org.kiwitcms.java.api;
 
-import net.minidev.json.JSONArray;
-import net.minidev.json.JSONObject;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -17,88 +13,13 @@ import static org.mockito.ArgumentMatchers.*;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kiwitcms.java.junit.KiwiTcmsExtension;
-import org.kiwitcms.java.model.TestCase;
-import org.kiwitcms.java.model.TestRun;
 import org.mockito.Mockito;
 
 import static org.kiwitcms.java.api.KiwiJsonRpcClient.*;
 
-@ExtendWith(KiwiTcmsExtension.class)
+
+//@ExtendWith(KiwiTcmsExtension.class)
 public class KiwiJsonRpcClientTest {
-
-    @Disabled("Causes failures, not sure why")
-    @Test
-    public void createNewTCTest(){
-        KiwiJsonRpcClient spy = Mockito.spy(new KiwiJsonRpcClient());
-
-        // props to test
-        String product = "product_id";
-        String summary = "summary";
-
-        // test object
-        JSONObject json = new JSONObject();
-        json.put(product, 345);
-        json.put(summary, "Test Summary");
-        // Prevent/stub logic in super.method()
-        Mockito.doReturn(json).when((BaseRpcClient) spy).callPosParamService(anyString(), anyList());
-
-        TestCase expectedTC = new TestCase();
-        expectedTC.setProductId(345);
-        expectedTC.setSummary("Test Summary");
-        assertThat(spy.createNewTC(345, "Test Summary"), Matchers.samePropertyValuesAs(expectedTC));
-    }
-
-
-    @Test
-    public void getRunWhenValidIdTest() {
-        KiwiJsonRpcClient spy = Mockito.spy(new KiwiJsonRpcClient());
-
-        // test object
-        JSONObject json = new JSONObject();
-        json.put("id", 1);
-        JSONArray array = new JSONArray();
-        array.add(json);
-        // Prevent/stub logic in super.method()
-        Mockito.doReturn(array).when((BaseRpcClient) spy).callPosParamService(anyString(), anyList());
-
-        TestRun expectedResult = new TestRun();
-        expectedResult.seId(1);
-        assertThat(spy.getRun(1), Matchers.samePropertyValuesAs(expectedResult));
-    }
-
-    @Test
-    public void getRunWhenServiceErrorTest() {
-        KiwiJsonRpcClient spy = Mockito.spy(new KiwiJsonRpcClient());
-
-        // Prevent/stub logic in super.method()
-        Mockito.doReturn(null).when((BaseRpcClient) spy).callPosParamService(anyString(), anyList());
-        assertThat(spy.getRun(1), is(equalTo(null)));
-    }
-
-    @Test
-    public void getRunWhenMissingIdTest() {
-        KiwiJsonRpcClient spy = Mockito.spy(new KiwiJsonRpcClient());
-
-        // Prevent/stub logic in super.method()
-        Mockito.doReturn(new JSONArray()).when((BaseRpcClient) spy).callPosParamService(anyString(), anyList());
-        assertThat(spy.getRun(-1), is(equalTo(null)));
-    }
-
-    @Disabled("Causes failures, not sure why")
-    @Test
-    public void getRunWhenServiceResponceMisformattedTest() {
-        KiwiJsonRpcClient spy = Mockito.spy(new KiwiJsonRpcClient());
-
-        // test object
-        JSONObject json = new JSONObject();
-        json.put("id", "rt");
-        JSONArray array = new JSONArray();
-        array.add(json);
-        // Prevent/stub logic in super.method()
-        Mockito.doReturn(array).when((BaseRpcClient) spy).callPosParamService(anyString(), anyList());
-
-        assertThat(spy.getRun(1), is(equalTo(null)));
-    }
 
     @Test
     void loginWithCorrectCredentialsTest() {
@@ -117,7 +38,8 @@ public class KiwiJsonRpcClientTest {
         // Prevent/stub logic in super.method()
         Mockito.doReturn(null).when((BaseRpcClient) spy).callPosParamService(eq(LOGIN_METHOD), anyList());
 
-        assertThat(spy.login("daenerys", "targaryen"), is(equalTo(null)));    }
+        assertThat(spy.login("daenerys", "targaryen"), is(equalTo(null)));
+    }
 
     @Test
     void loginWithEmptyParamsTest() {

--- a/src/test/java/org/kiwitcms/java/api/KiwiJsonRpcClientTest.java
+++ b/src/test/java/org/kiwitcms/java/api/KiwiJsonRpcClientTest.java
@@ -11,14 +11,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.kiwitcms.java.junit.KiwiTcmsExtension;
 import org.mockito.Mockito;
 
 import static org.kiwitcms.java.api.KiwiJsonRpcClient.*;
 
 
-@ExtendWith(KiwiTcmsExtension.class)
 public class KiwiJsonRpcClientTest {
 
     @Test

--- a/src/test/java/org/kiwitcms/java/api/KiwiJsonRpcClientTest.java
+++ b/src/test/java/org/kiwitcms/java/api/KiwiJsonRpcClientTest.java
@@ -18,7 +18,7 @@ import org.mockito.Mockito;
 import static org.kiwitcms.java.api.KiwiJsonRpcClient.*;
 
 
-//@ExtendWith(KiwiTcmsExtension.class)
+@ExtendWith(KiwiTcmsExtension.class)
 public class KiwiJsonRpcClientTest {
 
     @Test

--- a/src/test/java/org/kiwitcms/java/api/KiwiTestingJsonRpcClientTest.java
+++ b/src/test/java/org/kiwitcms/java/api/KiwiTestingJsonRpcClientTest.java
@@ -34,10 +34,11 @@ public class KiwiTestingJsonRpcClientTest {
         String priorityId = "priority_id";
         String summary = "summary";
         String caseStatusId = "case_status";
-
+        String productId = "product";
 
         // test object
         JSONObject json = new JSONObject();
+        json.put(productId, 33);
         json.put(categoryId, 4);
         json.put(priorityId, 0);
         json.put(caseStatusId, 1);
@@ -47,10 +48,12 @@ public class KiwiTestingJsonRpcClientTest {
         Mockito.doReturn(json).when((BaseRpcClient) spy).callPosParamService(eq(CREATE_TC_METHOD), anyList());
 
         TestCase expectedTC = new TestCase();
+        //inconsistent tcms behaviour
+        expectedTC.setProduct("33");
         expectedTC.setCategoryId(4);
         expectedTC.setPriorityId(0);
         expectedTC.setSummary("Test Summary");
-        assertThat(spy.createNewTC(4, 0, 1, "Test Summary"), Matchers.samePropertyValuesAs(expectedTC));
+        assertThat(spy.createNewTC(33, 4, 0, 1, "Test Summary"), Matchers.samePropertyValuesAs(expectedTC));
     }
 
     @Test

--- a/src/test/java/org/kiwitcms/java/api/KiwiTestingJsonRpcClientTest.java
+++ b/src/test/java/org/kiwitcms/java/api/KiwiTestingJsonRpcClientTest.java
@@ -22,10 +22,9 @@ import static org.kiwitcms.java.api.KiwiTestingJsonRpcClient.TEST_CASE_STATUS_FI
 import static org.mockito.ArgumentMatchers.*;
 
 
-//@ExtendWith(KiwiTcmsExtension.class)
+@ExtendWith(KiwiTcmsExtension.class)
 public class KiwiTestingJsonRpcClientTest {
 
-    //    @Disabled("Causes failures, not sure why")
     @Test
     public void createNewTCTest() {
         KiwiTestingJsonRpcClient spy = Mockito.spy(new KiwiTestingJsonRpcClient());
@@ -89,7 +88,6 @@ public class KiwiTestingJsonRpcClientTest {
         assertThat(spy.getRun(-1), is(equalTo(null)));
     }
 
-    //    @Disabled("Causes failures, not sure why")
     @Test
     public void getRunWhenServiceResponceMisformattedTest() {
         KiwiTestingJsonRpcClient spy = Mockito.spy(new KiwiTestingJsonRpcClient());

--- a/src/test/java/org/kiwitcms/java/api/KiwiTestingJsonRpcClientTest.java
+++ b/src/test/java/org/kiwitcms/java/api/KiwiTestingJsonRpcClientTest.java
@@ -1,0 +1,107 @@
+// Copyright (c) 2018-2019 Aneta Petkova <aneta.v.petkova@gmail.com>
+
+// Licensed under the GPLv3: https://www.gnu.org/licenses/gpl.html
+
+package org.kiwitcms.java.api;
+
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwitcms.java.junit.KiwiTcmsExtension;
+import org.kiwitcms.java.model.TestCase;
+import org.kiwitcms.java.model.TestRun;
+import org.mockito.Mockito;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.kiwitcms.java.api.KiwiTestingJsonRpcClient.CREATE_TC_METHOD;
+import static org.kiwitcms.java.api.KiwiTestingJsonRpcClient.TEST_CASE_STATUS_FILTER;
+import static org.mockito.ArgumentMatchers.*;
+
+
+//@ExtendWith(KiwiTcmsExtension.class)
+public class KiwiTestingJsonRpcClientTest {
+
+    //    @Disabled("Causes failures, not sure why")
+    @Test
+    public void createNewTCTest() {
+        KiwiTestingJsonRpcClient spy = Mockito.spy(new KiwiTestingJsonRpcClient());
+
+        // props to test
+        String categoryId = "category_id";
+        String priorityId = "priority_id";
+        String summary = "summary";
+        String caseStatusId = "case_status";
+
+
+        // test object
+        JSONObject json = new JSONObject();
+        json.put(categoryId, 4);
+        json.put(priorityId, 0);
+        json.put(caseStatusId, 1);
+        json.put(summary, "Test Summary");
+        // Prevent/stub logic in super.method()
+        Mockito.doReturn(1).when((BaseRpcClient) spy).callPosParamService(eq(TEST_CASE_STATUS_FILTER), anyList());
+        Mockito.doReturn(json).when((BaseRpcClient) spy).callPosParamService(eq(CREATE_TC_METHOD), anyList());
+
+        TestCase expectedTC = new TestCase();
+        expectedTC.setCategoryId(4);
+        expectedTC.setPriorityId(0);
+        expectedTC.setSummary("Test Summary");
+        assertThat(spy.createNewTC(4, 0, 1, "Test Summary"), Matchers.samePropertyValuesAs(expectedTC));
+    }
+
+    @Test
+    public void getRunWhenValidIdTest() {
+        KiwiTestingJsonRpcClient spy = Mockito.spy(new KiwiTestingJsonRpcClient());
+
+        // test object
+        JSONObject json = new JSONObject();
+        json.put("id", 1);
+        JSONArray array = new JSONArray();
+        array.add(json);
+        // Prevent/stub logic in super.method()
+        Mockito.doReturn(array).when((BaseRpcClient) spy).callPosParamService(anyString(), anyList());
+
+        TestRun expectedResult = new TestRun();
+        expectedResult.seId(1);
+        assertThat(spy.getRun(1), Matchers.samePropertyValuesAs(expectedResult));
+    }
+
+    @Test
+    public void getRunWhenServiceErrorTest() {
+        KiwiTestingJsonRpcClient spy = Mockito.spy(new KiwiTestingJsonRpcClient());
+
+        // Prevent/stub logic in super.method()
+        Mockito.doReturn(null).when((BaseRpcClient) spy).callPosParamService(anyString(), anyList());
+        assertThat(spy.getRun(1), is(equalTo(null)));
+    }
+
+    @Test
+    public void getRunWhenMissingIdTest() {
+        KiwiTestingJsonRpcClient spy = Mockito.spy(new KiwiTestingJsonRpcClient());
+
+        // Prevent/stub logic in super.method()
+        Mockito.doReturn(new JSONArray()).when((BaseRpcClient) spy).callPosParamService(anyString(), anyList());
+        assertThat(spy.getRun(-1), is(equalTo(null)));
+    }
+
+    //    @Disabled("Causes failures, not sure why")
+    @Test
+    public void getRunWhenServiceResponceMisformattedTest() {
+        KiwiTestingJsonRpcClient spy = Mockito.spy(new KiwiTestingJsonRpcClient());
+
+        // test object
+        JSONObject json = new JSONObject();
+        json.put("id", "rt");
+        JSONArray array = new JSONArray();
+        array.add(json);
+        // Prevent/stub logic in super.method()
+        Mockito.doReturn(array).when((BaseRpcClient) spy).callPosParamService(anyString(), anyList());
+
+        assertThat(spy.getRun(1), is(equalTo(null)));
+    }
+}

--- a/src/test/java/org/kiwitcms/java/api/KiwiTestingJsonRpcClientTest.java
+++ b/src/test/java/org/kiwitcms/java/api/KiwiTestingJsonRpcClientTest.java
@@ -8,8 +8,6 @@ import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.kiwitcms.java.junit.KiwiTcmsExtension;
 import org.kiwitcms.java.model.TestCase;
 import org.kiwitcms.java.model.TestRun;
 import org.mockito.Mockito;
@@ -22,7 +20,6 @@ import static org.kiwitcms.java.api.KiwiTestingJsonRpcClient.TEST_CASE_STATUS_FI
 import static org.mockito.ArgumentMatchers.*;
 
 
-@ExtendWith(KiwiTcmsExtension.class)
 public class KiwiTestingJsonRpcClientTest {
 
     @Test


### PR DESCRIPTION
RPC client should not be aware of dependencies between objects (TestCase needing category, etc.). Neither constructors.

The main class was split into one responsible for test objects, and one for product.
Fix for multiple TestPlan creation.
Tests fixed & re-enabled.