### PR TITLE
Test and build with openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - openjdk8
 install:
   - |
         echo "[tcms]" > ~/.tcms.conf


### PR DESCRIPTION
because of
https://github.com/trautonen/coveralls-maven-plugin/issues/112
http://mail.openjdk.java.net/pipermail/jdk9-dev/2016-May/004309.html