### PR TITLE
Switch to Codecov b/c Coveralls don't support JaCoCo

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,4 +46,10 @@ jobs:
         export TCMS_BUILD=$(echo $GITHUB_SHA | cut -c1-7)
 
         mvn checkstyle:checkstyle
-        mvn test -B jacoco:report # coveralls:report
+        mvn test -B jacoco:report
+
+    - name: Submit coverage report to codecov.io
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./target/site/jacoco/jacoco.xml
+        verbose: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ JUnit 5 plugin for Kiwi TCMS
 ----------------------------
 
 [![Build Status](https://travis-ci.org/kiwitcms/junit-plugin.svg?branch=master)](https://travis-ci.org/kiwitcms/junit-plugin)
-[![Coverage Status](https://coveralls.io/repos/github/kiwitcms/junit-plugin/badge.svg)](https://coveralls.io/github/kiwitcms/junit-plugin)
+[![Coverage Status](https://codecov.io/gh/kiwitcms/junit-plugin/branch/master/graph/badge.svg?token=2BCuQxHh2J)](https://codecov.io/gh/kiwitcms/junit-plugin)
 [![TP for kiwitcms/junit-plugin (master)](https://img.shields.io/badge/kiwi%20tcms-results-9ab451.svg)](https://tcms.kiwitcms.org/plan/25/)
 [![Maven Central](https://img.shields.io/maven-central/v/org.kiwitcms.java/kiwitcms-junit-plugin.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.kiwitcms.java%22%20AND%20a:%22kiwitcms-junit-plugin%22)
 [![Tidelift](https://tidelift.com/badges/package/pypi/kiwitcms)](https://tidelift.com/subscription/pkg/pypi-kiwitcms?utm_source=pypi-kiwitcms&utm_medium=github&utm_campaign=junit-plugin)

--- a/pom.xml
+++ b/pom.xml
@@ -147,14 +147,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.eluder.coveralls</groupId>
-                <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.3.0</version>
-                <configuration>
-                    <sourceEncoding>UTF8</sourceEncoding>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.6</version>


### PR DESCRIPTION
in particular JaCoCo can't produce an lcov file needed by the latest
coveralls GitHub action.