### PR TITLE
Update junit dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.5.2</version>
+            <version>5.8.2</version>
             <scope>compile</scope>
         </dependency>
 
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.2</version>
+            <version>5.8.2</version>
             <scope>compile</scope>
         </dependency>
 
@@ -209,7 +209,7 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.5.2</version>
+            <version>1.8.2</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
- Bump junit-jupiter-api from 5.5.2 to 5.8.2. Closes #222
- Bump junit-platform-launcher from 1.5.2 to 1.8.2. Closes #223
- Bump junit-jupiter-engine from 5.5.2 to 5.8.2. Closes #224