### PR TITLE
Forward compatibility with upcoming Kiwi TCMS v11.0

### DIFF
--- a/src/main/java/org/kiwitcms/java/api/RpcClient.java
+++ b/src/main/java/org/kiwitcms/java/api/RpcClient.java
@@ -132,14 +132,22 @@ public class RpcClient extends BaseRpcClient {
         }
     }
 
-    public TestExecution addTestCaseToRunId(int runId, int caseId) {
+    public TestExecution[] addTestCaseToRunId(int runId, int caseId) {
         Map<String, Object> params = new HashMap<>();
         params.put("run_id", runId);
         params.put("case_id", caseId);
 
-        JSONObject json = (JSONObject) executeViaNamedParams(ADD_TC_TO_RUN_METHOD, params);
+        Object response = executeViaNamedParams(ADD_TC_TO_RUN_METHOD, params);
         try {
-            return new ObjectMapper().readValue(json.toJSONString(), TestExecution.class);
+            if (response instanceof JSONObject) {
+                // Kiwi TCMS v10.5 or earlier
+                TestExecution execution = new ObjectMapper().readValue(((JSONObject)response).toJSONString(), TestExecution.class);
+                TestExecution[] executions = {execution};
+                return executions;
+            } else {
+                // Kiwi TCMS v11.0 or later
+                return new ObjectMapper().readValue(((JSONArray)response).toJSONString(), TestExecution[].class);
+            }
         } catch (IOException e) {
             e.printStackTrace();
             return null;

--- a/src/main/java/org/kiwitcms/java/junit/TestDataEmitter.java
+++ b/src/main/java/org/kiwitcms/java/junit/TestDataEmitter.java
@@ -101,11 +101,11 @@ public class TestDataEmitter {
         for (TestMethod test : tests) {
             TestCase testCase = client.getOrCreateTestCase(productId, categoryId, priorityId, test.getSummary());
             client.addTestCaseToPlan(testPlanId, testCase.getCaseId());
-// TODO: this method should accept casesInTestRun and not call RPC if the TestCase
-// has already been added inside the TestRun
-            TestExecution testExecution = client.addTestCaseToRunId(runId, testCase.getCaseId());
 
-            client.updateTestExecution(testExecution.getTcRunId(), test.getTestExecutionStatus());
+            TestExecution[] executions = client.addTestCaseToRunId(runId, testCase.getCaseId());
+            for (TestExecution testExecution : executions) {
+                client.updateTestExecution(testExecution.getTcRunId(), test.getTestExecutionStatus());
+            }
         }
     }
 


### PR DESCRIPTION
b/c TestRun.add_case() API will return a list of objects.
However keeps backwards compatibility with older versions