### PR TITLE
Add annotation to tag tests by test case ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ This plugin extends `org.junit.jupiter.api.extension.Extension` and has
 `junit.jupiter.extensions.autodetection.enabled=true` configured by default in
 `pom.xml`. This means Jupiter will pick it up automatically.
 
+You can point each executed test case to a specific case ID by annotating `@Test` method with `@TcmsTestCaseId(int)`,
+where `int` is the test case ID. See the `KiwiTcmsExtension` example below.
+If the test case is not found searching by ID, plugin will default to standard search method.
+You can find the case ID in your TCMS instance URL (example: https://tcms.server/case/1)
+or on the test case page in the test case name (TC-**1**: Test case 1).
+
 You may alternatively decorate your test suite with the `KiwiTcmsExtension` class
 but that should be redundant:
 
@@ -36,6 +42,7 @@ but that should be redundant:
     @ExtendWith(KiwiTcmsExtension.class)
     public class KiwiJsonRpcClientTest {
         @Test
+        @TcmsTestCaseId(11)
         public void yourTest(){
             assertThat(...);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.kiwitcms.java</groupId>
     <artifactId>kiwitcms-junit-plugin</artifactId>
     <packaging>jar</packaging>
-    <version>12.5</version>
+    <version>12.6</version>
 
     <name>kiwitcms-junit-plugin</name>
     <description>JUnit 5 plugin for Kiwi TCMS.</description>

--- a/src/main/java/org/kiwitcms/java/api/RpcClient.java
+++ b/src/main/java/org/kiwitcms/java/api/RpcClient.java
@@ -411,4 +411,22 @@ public class RpcClient extends BaseRpcClient {
             return null;
         }
     }
+    
+    public TestCase getTestCaseById(int testCaseId) {
+        Map<String, Object> filter = new HashMap<>();
+        filter.put("id", testCaseId);
+        JSONArray jsonArray = (JSONArray) executeViaPositionalParams(TEST_CASE_FILTER, Arrays.asList(filter));
+        if (jsonArray == null || jsonArray.isEmpty()) {
+            System.out.printf("Case ID \"%s\" not found%n", testCaseId);
+            return null;
+        }
+
+        try {
+            TestCase[] testCases = new ObjectMapper().readValue(jsonArray.toJSONString(), TestCase[].class);
+            return testCases[0];
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
 }

--- a/src/main/java/org/kiwitcms/java/api/RpcClient.java
+++ b/src/main/java/org/kiwitcms/java/api/RpcClient.java
@@ -411,7 +411,7 @@ public class RpcClient extends BaseRpcClient {
             return null;
         }
     }
-    
+
     public TestCase getTestCaseById(int testCaseId) {
         Map<String, Object> filter = new HashMap<>();
         filter.put("id", testCaseId);

--- a/src/main/java/org/kiwitcms/java/junit/KiwiTcmsExtension.java
+++ b/src/main/java/org/kiwitcms/java/junit/KiwiTcmsExtension.java
@@ -5,6 +5,7 @@
 package org.kiwitcms.java.junit;
 
 import org.kiwitcms.java.config.Config;
+import org.kiwitcms.java.model.TcmsTestCaseId;
 import org.kiwitcms.java.model.TestMethod;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
@@ -49,6 +50,10 @@ public class KiwiTcmsExtension extends SummaryGeneratingListener  implements Aft
                 test.result = "PASS";
             }
             test.containingClass = method.getDeclaringClass().getSimpleName();
+            if (method.isAnnotationPresent(TcmsTestCaseId.class)) {
+                TcmsTestCaseId tcmsTestCaseId = method.getAnnotation(TcmsTestCaseId.class);
+                test.id = tcmsTestCaseId.value();
+            }
             tests.add(test);
         }
     }

--- a/src/main/java/org/kiwitcms/java/junit/TestDataEmitter.java
+++ b/src/main/java/org/kiwitcms/java/junit/TestDataEmitter.java
@@ -6,6 +6,7 @@
 package org.kiwitcms.java.junit;
 
 import net.minidev.json.JSONObject;
+import org.apache.commons.lang3.ObjectUtils;
 import org.kiwitcms.java.api.RpcClient;
 import org.kiwitcms.java.config.Config;
 import org.kiwitcms.java.model.*;
@@ -100,9 +101,15 @@ public class TestDataEmitter {
         int testPlanId = getPlanId();
 
         for (TestMethod test : tests) {
-            TestCase testCase = client.getOrCreateTestCase(productId, categoryId, priorityId, test.getSummary());
+            TestCase testCase = null;
+            if (test.id != 0) {
+                testCase = client.getTestCaseById(test.id);
+            }
+            if (ObjectUtils.isEmpty(testCase)) {
+                testCase = client.getOrCreateTestCase(productId, categoryId, priorityId, test.getSummary());
+            }
             client.addTestCaseToPlan(testPlanId, testCase.getCaseId());
-
+    
             TestExecution[] executions = client.addTestCaseToRunId(runId, testCase.getCaseId());
             for (TestExecution testExecution : executions) {
                 client.updateTestExecution(testExecution.getTcRunId(), getTestExecutionStatusId(test.result));

--- a/src/main/java/org/kiwitcms/java/junit/TestDataEmitter.java
+++ b/src/main/java/org/kiwitcms/java/junit/TestDataEmitter.java
@@ -109,7 +109,7 @@ public class TestDataEmitter {
                 testCase = client.getOrCreateTestCase(productId, categoryId, priorityId, test.getSummary());
             }
             client.addTestCaseToPlan(testPlanId, testCase.getCaseId());
-    
+
             TestExecution[] executions = client.addTestCaseToRunId(runId, testCase.getCaseId());
             for (TestExecution testExecution : executions) {
                 client.updateTestExecution(testExecution.getTcRunId(), getTestExecutionStatusId(test.result));

--- a/src/main/java/org/kiwitcms/java/model/TcmsTestCaseId.java
+++ b/src/main/java/org/kiwitcms/java/model/TcmsTestCaseId.java
@@ -1,0 +1,13 @@
+package org.kiwitcms.java.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TcmsTestCaseId
+{
+	int value();
+}

--- a/src/main/java/org/kiwitcms/java/model/TestMethod.java
+++ b/src/main/java/org/kiwitcms/java/model/TestMethod.java
@@ -11,6 +11,7 @@ public class TestMethod {
     public String containingClass;
     public String result;
     public Throwable exception;
+    public int id;
 
     public TestMethod(){};
 


### PR DESCRIPTION
- Added the ability to search exclusively by case ID with `@TcmsTestCaseId()` annotation to the `@Test` method.


If you have a nicely maintained Kiwi instance, where the test cases are manually added and your code doesn't reflect the names, then the TCMS junit plugin won't be able to find them properly (just by searching by name). By adding the `@TcmsTestCaseId()` annotation, you can override which test case is returned to the test plan. In case of invalid ID being provided the plugin will do the standard test case search.